### PR TITLE
feat(container-build): adding docker build for creating BeamMP servers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+ServerConfig.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use Ubuntu 22.04 as base image
+FROM ubuntu:22.04
+
+# Update the package lists
+RUN \
+  apt-get update && \
+  apt-get -y upgrade && \
+  apt-get install -y liblua5.4-0 libssl3 cmake make git \
+    zlib1g-dev libcurl4-openssl-dev curl lua5.4 lua5.4-dev \
+    libz-dev rapidjson-dev liblua5.4-dev libssl-dev \
+    libwebsocketpp-dev g++ libboost1.74-all-dev 
+
+COPY . /root
+WORKDIR /root
+
+# Build the BeamMP-Server
+RUN cmake . -DCMAKE_BUILD_TYPE=Release
+RUN make
+
+RUN ./BeamMP-Server-tests
+
+# Start the BeamMP-Server when the container is run
+CMD [ "./BeamMP-Server" ]

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ brew install curl zlib git make
 
 ### How to build
 
+#### Manual
+
 On Windows, use git-bash for these commands. On Linux, these should work in your shell.
 
 1. Make sure you have all [prerequisites](#prerequisites) installed
@@ -172,6 +174,17 @@ On Windows, use git-bash for these commands. On Linux, these should work in your
 8. You now have a `BeamMP-Server` file in your directory, which is executable with `./BeamMP-Server` (`.\BeamMP-Server.exe` for windows). Follow the (Windows or Linux, doesnt matter) instructions on the [wiki](https://wiki.beammp.com/en/home/server-installation) for further setup after installation (which we just did), such as port-forwarding and getting a key to actually run the server.
 
 *tip: to run the server in the background, simply (in bash, zsh, etc) run:* `nohup ./BeamMP-Server &`*.*
+
+#### Docker
+To build the ubuntu container run the following command:
+```
+docker compose build
+```
+
+To run the container:
+```
+docker compose up -d
+```
 
 ## Support
 The BeamMP project is supported by community donations via our [Patreon](https://www.patreon.com/BeamMP). This brings perks such as Patreon-only channels on our Discord, early access to new updates, and more server keys. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  beammp:
+    container_name: 'beammp'
+    build: .
+    tty: true
+    ports:
+      - '30814:30814'
+      - '30815:30815'
+    volumes:
+      - ./ServerConfig.toml:/root/ServerConfig.toml


### PR DESCRIPTION
## Goal
To build a ubuntu container that will build assets needed. The resulting container will run the BeamMP server and any machine that supports containers

## How Has This Been Tested?
The image is built using `./BeamMP-Server-tests` to validate the final container.
Testing was done manually using 
```
docker compose up -d --build
```
<img width="1268" alt="Screenshot 2023-12-05 at 10 40 37 PM" src="https://github.com/MiguelAPerez/BeamMP-Server/assets/15218573/f5e873e5-833c-4974-a7f0-6a43de2839dd">

<img width="929" alt="Screenshot 2023-12-05 at 10 56 00 PM" src="https://github.com/MiguelAPerez/BeamMP-Server/assets/15218573/435fe43f-d668-42ab-b64e-1576988a85ef">
